### PR TITLE
Allow ICC profiles to be found in texmf

### DIFF
--- a/colorspace.sty
+++ b/colorspace.sty
@@ -498,7 +498,7 @@
     % read the icc file and extract the space it applies to
     \ifx\pdffiledump\@undefined
       \directlua{
-      local icc = io.open([[#2]], "r")
+      local icc = io.open(kpse.find_file([[#2]]), "r")
       if icc then
         icc:seek("set", 16)
         tex.print([[\noexpand\csname @namedef\endcsname{spc@tempa}{]]


### PR DESCRIPTION
Using `kpse` to find a file (which _includes_ the cwd) allows to use globally available ICC profiles, such as from [the `colorprofiles` package](https://ctan.org/tex-archive/support/colorprofiles)